### PR TITLE
Fix trailing whitespace issue in 'Content' filter comparison

### DIFF
--- a/anndata2rdf/src/csv_parser.py
+++ b/anndata2rdf/src/csv_parser.py
@@ -56,6 +56,6 @@ if __name__ == "__main__":
     config_yaml = generate_author_cell_type_config()
     output_file_path = os.path.join(
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "config"),
-        "xcxg_author_cell_type.yaml",
+        "cxg_author_cell_type.yaml",
     )
     write_yaml_file(config_yaml, output_file_path)

--- a/anndata2rdf/src/csv_parser.py
+++ b/anndata2rdf/src/csv_parser.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.INFO)
 
 
 def generate_yaml_data(data):
-    filtered_df = data[data["Content"].str.lower() == "cell types"]
+    filtered_df = data[data["Content"].str.strip().str.lower() == "cell types"]
     grouped_data = filtered_df.groupby("h5ad link")
     _yaml_data = []
     for link, group_df in grouped_data:
@@ -56,6 +56,6 @@ if __name__ == "__main__":
     config_yaml = generate_author_cell_type_config()
     output_file_path = os.path.join(
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "config"),
-        "cxg_author_cell_type.yaml",
+        "xcxg_author_cell_type.yaml",
     )
     write_yaml_file(config_yaml, output_file_path)


### PR DESCRIPTION
This PR addresses an issue in the data filtering logic where entries in the `"Content"` column with trailing whitespace would fail to match against `"cell types"`. The `str.strip()` method has been added to remove any leading or trailing whitespace before performing the case-insensitive comparison.

#### Changes
- Modified the `"Content"` column comparison to use `str.strip()` before `str.lower()` to ensure accurate filtering.

#### Testing
- Verified the updated filter logic by running tests with sample data containing trailing whitespace. The comparison now correctly matches `"cell types"` regardless of extra spaces.

#### Note
This whitespace issue was previously overlooked because Google Sheets automatically handles and hides trailing whitespace in the UI, making it difficult to detect visually.

This update improves data consistency and accuracy in filtering. @dosumis @JABelfiore 