### PR TITLE
Add support for chunked download to handle large dataset files efficiently

### DIFF
--- a/anndata2rdf/requirements.txt
+++ b/anndata2rdf/requirements.txt
@@ -1,3 +1,4 @@
 pandasaurus-cxg
 pandas
 PyYAML~=6.0.1
+tqdm


### PR DESCRIPTION
This PR enhances the `download_dataset_with_url` method to handle large dataset files efficiently by downloading in 8 MB chunks and includes a progress bar to provide visual feedback during the download process. These updates improve memory management and user experience when handling large files (e.g., 50GB).

#### Changes
- **Chunked Download**: Added `stream=True` with a 8 MB chunk size to manage memory usage during download.
- **Progress Bar**: Integrated `tqdm` to display a real-time progress bar, showing download progress for large files.

#### Testing
- Verified with a large dataset to confirm successful download, complete file integrity, and correct progress display.

This enhancement optimizes memory usage, provides better user feedback, and increases reliability for large file downloads.