### PR TITLE
Refactor uniprot_ensembl_mapper to uniprot_gene_mapper

### DIFF
--- a/translator_api_mapper/src/pipeline_mapper.py
+++ b/translator_api_mapper/src/pipeline_mapper.py
@@ -1,10 +1,10 @@
 from gene_node_unifier.gene_node_unifier import gene_node_unifier
 from pr_uniprot_id_swapper.pr_uniprot_id_swapper import pr_uniprot_id_swapper
-from uniprot_ensembl_mapper.uniprot_ensembl_mapper import uniprot_ensembl_mapper
+from uniprot_gene_mapper.uniprot_gene_mapper import uniprot_gene_mapper
 
 # Swap CL PR term URIs with UniProtKB dbxref values CL_KG#53
 pr_uniprot_id_swapper()
 # Link from Proteins (uniprot) to Genes (Ensembl) CL_KG#73
-uniprot_ensembl_mapper()
+uniprot_gene_mapper()
 # Unify Genes (Ensembl) with NCBIGene nodes
 gene_node_unifier()

--- a/translator_api_mapper/src/pr_uniprot_id_swapper/pr_uniprot_id_swapper.py
+++ b/translator_api_mapper/src/pr_uniprot_id_swapper/pr_uniprot_id_swapper.py
@@ -1,9 +1,8 @@
 import logging
 from typing import List, Tuple
+
 import requests
-
-from SPARQLWrapper import SPARQLWrapper, JSON
-
+from SPARQLWrapper import JSON, SPARQLWrapper
 from utils.translator_utils import ENDPOINT_URL
 
 logging.basicConfig(level=logging.WARNING)
@@ -136,7 +135,9 @@ def update_triples_batch(pairs: List[Tuple[str, str]]):
         if response.status_code == 204:
             logger.info(f"Successfully updated a batch of {len(pairs)} updates.")
         else:
-            logger.error(f"Batch update failed. Status Code: {response.status_code} - {response.text}")
+            logger.error(
+                f"Batch update failed. Status Code: {response.status_code} - {response.text}"
+            )
     except requests.exceptions.RequestException as e:
         logger.error(f"Batch update request failed: {e}")
 
@@ -148,7 +149,7 @@ def pr_uniprot_id_swapper():
 
     update_batch_size = 1000
     for i in range(0, len(all_tuples), update_batch_size):
-        batch_list = all_tuples[i:i + update_batch_size]
+        batch_list = all_tuples[i : i + update_batch_size]
         update_triples_batch(batch_list)
 
 

--- a/translator_api_mapper/src/uniprot_gene_mapper/uniprot_gene_mapper.py
+++ b/translator_api_mapper/src/uniprot_gene_mapper/uniprot_gene_mapper.py
@@ -2,15 +2,12 @@ import logging
 from typing import List
 
 import requests
-
 from utils.translator_utils import (
     BATCH_SIZE,
     ENDPOINT_URL,
-    ENSEMBL_PREFIX,
-    ENSEMBL_SPARQL_QUERY,
+    PREFIXES,
     RO_0003000,
-    UNIPROT_PREFIX,
-    UNIPROT_SPARQL_QUERY,
+    build_sparql_query,
     get_normalized_curies,
     run_query,
     uri_to_curie,
@@ -32,8 +29,8 @@ def insert_triples_in_batch(triples: List[str]):
     # Use the prefix variables in the SPARQL INSERT query
     insert_query = f"""
     PREFIX RO: <http://purl.obolibrary.org/obo/RO_>
-    PREFIX ensembl: <{ENSEMBL_PREFIX}>
-    PREFIX uniprot: <{UNIPROT_PREFIX}>
+    PREFIX ensembl: <{PREFIXES['ensembl']}>
+    PREFIX uniprot: <{PREFIXES['uniprot']}>
 
     INSERT DATA {{
         {' '.join(triples)}
@@ -54,33 +51,40 @@ def insert_triples_in_batch(triples: List[str]):
         logger.error(f"Request failed: {e}")
 
 
-def uniprot_ensembl_mapper():
+def uniprot_gene_mapper():
     # Retrieve UniProt and Ensembl terms
-    uniprot_terms = run_query(UNIPROT_SPARQL_QUERY)
+    uniprot_terms = run_query(build_sparql_query(PREFIXES["uniprot"]))
     uniprot_curie_list = uri_to_curie(uniprot_terms)
-    ensembl_terms = run_query(ENSEMBL_SPARQL_QUERY)
-    ensembl_curie_list = uri_to_curie(ensembl_terms)
+    ensembl_terms = run_query(build_sparql_query(PREFIXES["ensembl"]))
+    ncbigene_terms = run_query(build_sparql_query(PREFIXES["ncbigene"]))
+    gene_curie_list = uri_to_curie(ensembl_terms) + uri_to_curie(ncbigene_terms)
 
     # Get mappings
     normalized_curie_dict = get_normalized_curies(
         uniprot_curie_list,
         source_field="equivalent_identifiers",
-        filter_keywords=["ENSEMBL"],
+        filter_keywords=["NCBIGene", "ENSEMBL"],
     )
 
     triples_batch = []
-    count = 0
-    missing_count = 0
+    ensembl_count = 0
+    ncbigene_count = 0
+    ensembl_missing_count = 0
+    ncbigene_missing_count = 0
 
-    for uni, ensembl_list in normalized_curie_dict.items():
-        for ensembl_id in ensembl_list:
-            count += 1
+    for uni, gene_list in normalized_curie_dict.items():
+        for gene_curie in gene_list:
             # Convert the CURIE back to a full URI using the prefix variables
-            ensembl_uri = ensembl_id.replace("ENSEMBL:", ENSEMBL_PREFIX)
-            uniprot_uri = uni.replace("UniProtKB:", UNIPROT_PREFIX)
+            if gene_curie.startswith("ENSEMBL:"):
+                gene_uri = gene_curie.replace("ENSEMBL:", PREFIXES["ensembl"])
+                ensembl_count += 1
+            elif gene_curie.startswith("NCBIGene:"):
+                gene_uri = gene_curie.replace("NCBIGene:", PREFIXES["ncbigene"])
+                ncbigene_count += 1
+            uniprot_uri = uni.replace("UniProtKB:", PREFIXES["uniprot"])
 
-            if ensembl_id in ensembl_curie_list:
-                triple = f"<{ensembl_uri}> <{RO_0003000}> <{uniprot_uri}> ."
+            if gene_curie in gene_curie_list:
+                triple = f"<{gene_uri}> <{RO_0003000}> <{uniprot_uri}> ."
                 triples_batch.append(triple)
 
                 # Insert in batches
@@ -88,15 +92,18 @@ def uniprot_ensembl_mapper():
                     insert_triples_in_batch(triples_batch)
                     triples_batch = []
 
-            elif "ENSG" in ensembl_id:
-                missing_count += 1
+            elif "ENSG" in gene_curie:
+                ensembl_missing_count += 1
+            elif "NCBIGene" in gene_curie:
+                ncbigene_missing_count += 1
 
     # Insert remaining triples (if any)
     if triples_batch:
         insert_triples_in_batch(triples_batch)
 
-    logger.info(f"Out of {count} ENSEMBL IDs, {missing_count} are missing")
+    logger.info(f"Out of {ensembl_count} ENSEMBL IDs, {ensembl_missing_count} are missing")
+    logger.info(f"Out of {ncbigene_count} NCBIGene IDs, {ncbigene_missing_count} are missing")
 
 
 if __name__ == "__main__":
-    uniprot_ensembl_mapper()
+    uniprot_gene_mapper()

--- a/translator_api_mapper/src/utils/translator_utils.py
+++ b/translator_api_mapper/src/utils/translator_utils.py
@@ -9,31 +9,20 @@ logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-UNIPROT_PREFIX = "https://identifiers.org/uniprot/"
-UNIPROT_SPARQL_QUERY = f"""
-SELECT DISTINCT ?s
-WHERE {{ 
-  ?s a ?o. FILTER(contains(str(?s), "{UNIPROT_PREFIX}"))
-}}
-"""
-ENSEMBL_PREFIX = "http://identifiers.org/ensembl/"
-ENSEMBL_SPARQL_QUERY = f"""
-SELECT DISTINCT ?s
-WHERE {{ 
-  ?s a ?o. FILTER(contains(str(?s), "{ENSEMBL_PREFIX}"))
-}}
-"""
-NCBIGene_PREFIX = "http://identifiers.org/ncbigene/"
-
+PREFIXES = {
+    "uniprot": "https://identifiers.org/uniprot/",
+    "ensembl": "http://identifiers.org/ensembl/",
+    "ncbigene": "http://identifiers.org/ncbigene/",
+}
 # Node Normalization Endpoint
 NODE_NORMALIZATION_URL = "https://nodenormalization-sri.renci.org/get_normalized_nodes"
 # RDF4J local endpoint configuration
-ENDPOINT_URL = os.getenv(
-    "ENDPOINT_URL", "http://triplestore:8080/rdf4j-server/repositories/obask"
-)
 # ENDPOINT_URL = os.getenv(
-#     "ENDPOINT_URL", "http://localhost:8081/rdf4j-server/repositories/obask"
+#     "ENDPOINT_URL", "http://triplestore:8080/rdf4j-server/repositories/obask"
 # )
+ENDPOINT_URL = os.getenv(
+    "ENDPOINT_URL", "http://localhost:8081/rdf4j-server/repositories/obask"
+)
 # RO Relation: Gene produces Protein
 RO_0003000 = "http://purl.obolibrary.org/obo/RO_0003000"
 
@@ -42,6 +31,15 @@ BATCH_SIZE = 1000
 # Configure the SPARQL query endpoint
 sparql_query = SPARQLWrapper(ENDPOINT_URL)
 sparql_query.setReturnFormat(JSON)
+
+
+def build_sparql_query(prefix: str) -> str:
+    return f"""
+    SELECT DISTINCT ?s
+    WHERE {{ 
+      ?s a ?o. FILTER(contains(str(?s), "{prefix}"))
+    }}
+    """
 
 
 def run_query(query: str) -> List[str]:
@@ -60,10 +58,12 @@ def uri_to_curie(uri_list: List[str]) -> List[str]:
     """Converts RDF URIs to CURIEs for use with the Translator API."""
     curie_list = []
     for uri in uri_list:
-        if uri.startswith(UNIPROT_PREFIX):
-            curie_list.append(f"UniProtKB:{uri.replace(UNIPROT_PREFIX, '')}")
-        elif uri.startswith(ENSEMBL_PREFIX):
-            curie_list.append(f"ENSEMBL:{uri.replace(ENSEMBL_PREFIX, '')}")
+        if uri.startswith(PREFIXES["uniprot"]):
+            curie_list.append(f"UniProtKB:{uri.replace(PREFIXES['uniprot'], '')}")
+        elif uri.startswith(PREFIXES["ensembl"]):
+            curie_list.append(f"ENSEMBL:{uri.replace(PREFIXES['ensembl'], '')}")
+        elif uri.startswith(PREFIXES["ncbigene"]):
+            curie_list.append(f"NCBIGene:{uri.replace(PREFIXES['ncbigene'], '')}")
     return curie_list
 
 


### PR DESCRIPTION
This PR renames and generalizes the `uniprot_ensembl_mapper` module to `uniprot_gene_mapper` in order to support mapping **UniProt protein nodes to multiple gene sources**, not just Ensembl.

#### Changes:

* **Renamed**: `uniprot_ensembl_mapper.py` → `uniprot_gene_mapper.py`
* **Refactored logic** to accommodate additional gene identifier systems (e.g., NCBI Gene)
* **Improved code structure** for future extensibility and reduced redundancy

#### Rationale:

* Prepares the pipeline for broader gene mapping use cases
* Aligns module naming with expanded scope and functionality

