### PR TITLE
Add CL_KG summary report page to documentation navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,5 +6,7 @@ nav:
   - Content Analysis: queries_for_content_analysis.md
   - Dataset Curation Guidelines: dataset_curation_guidelines.md
   - Schema: schema.md
+  - Reports:
+      - CL_KG Summary: reports/clkg-summary.md
 theme: readthedocs
 docs_dir: docs


### PR DESCRIPTION
Fix #36 

This PR updates the MkDocs configuration to include the newly generated CL_KG summary report (`docs/reports/clkg-summary.md`) in the documentation navigation.