### PR TITLE
Pin pandasaurus-cxg to 0.2.4 for anndata2rdf release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,8 @@ cython_debug/
 
 anndata2rdf/src/config/*
 *.bak
+
+# Ignore root-level data/scripts only
+/*.py
+/*.csv
+/*.xlsx

--- a/anndata2rdf/requirements.txt
+++ b/anndata2rdf/requirements.txt
@@ -1,4 +1,4 @@
-pandasaurus-cxg
+pandasaurus-cxg==0.2.4
 pandas
 PyYAML~=6.0.1
 tqdm


### PR DESCRIPTION
This PR pins pandasaurus-cxg to 0.2.4 in requirements.txt so the next release image consistently includes the intended version.