### PR TITLE
Add bitmap generation to anndata2rdf runtime pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,11 @@ cython_debug/
 **/.DS_Store
 
 anndata2rdf/src/config/*
+anndata2rdf/src/dataset/*
+anndata2rdf/src/graph/*
+anndata2rdf/src/bitmaps/*
+!anndata2rdf/src/bitmaps/README.md
+anndata2rdf/.mplconfig/
 *.bak
 
 # Ignore root-level data/scripts only

--- a/anndata2rdf/Dockerfile
+++ b/anndata2rdf/Dockerfile
@@ -11,9 +11,10 @@ COPY requirements.txt ./
 RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir -r requirements.txt -U
 
-RUN mkdir -p src/config src/curated_data src/dataset src/graph
+RUN mkdir -p src/config src/curated_data src/dataset src/graph src/bitmaps
 
 COPY src/csv_parser.py ./src
+COPY src/bitmap_builder.py ./src
 COPY src/pull_anndata.py ./src
 COPY src/generate_rdf.py ./src
 COPY src/process.py ./src

--- a/anndata2rdf/docker-compose.yml
+++ b/anndata2rdf/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - ./src/config:/app/src/config
       - ./src/curated_data:/app/src/curated_data
       - ./src/dataset:/app/src/dataset
-      - obask_data:/app/src/graph
+      - obask_graph_data:/app/src/graph
+      - clkg_bitmap_data:/app/src/bitmaps
 volumes:
-  obask_data:
+  obask_graph_data:
+  clkg_bitmap_data:

--- a/anndata2rdf/requirements.txt
+++ b/anndata2rdf/requirements.txt
@@ -1,4 +1,6 @@
-pandasaurus-cxg==0.2.5
+pandasaurus-cxg==0.2.8
+cellxgene-census
 pandas
+pyroaring
 PyYAML~=6.0.1
 tqdm

--- a/anndata2rdf/src/bitmap_builder.py
+++ b/anndata2rdf/src/bitmap_builder.py
@@ -1,0 +1,247 @@
+import logging
+import os
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Tuple
+from urllib.parse import unquote
+
+import cellxgene_census
+import pandas as pd
+from pyroaring import BitMap
+from rdflib import RDF, RDFS, URIRef
+
+logger = logging.getLogger(__name__)
+
+CELL_CLUSTER_CLASS = URIRef("http://purl.obolibrary.org/obo/PCL_0010001")
+UUID_PATTERN = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+
+@dataclass(frozen=True)
+class ClusterBitmapRecord:
+    node_iri: str
+    cluster_label: str
+    author_label_column: str
+    author_label_value: str
+    census_dataset_id: str
+    census_version: str
+
+
+def build_cluster_bitmaps(aea, gg, output_dir: str) -> int:
+    os.makedirs(output_dir, exist_ok=True)
+
+    obs = _get_anndata_obs(aea)
+    if "observation_joinid" not in obs.columns:
+        logger.warning("Skipping bitmap build: 'observation_joinid' missing from AnnData obs.")
+        return 0
+
+    graph = _get_rdf_graph(gg)
+    records = list(iter_cluster_bitmap_records(graph))
+    if not records:
+        logger.warning("Skipping bitmap build: no cluster bitmap records found in RDF graph.")
+        return 0
+
+    joinid_map_cache: Dict[Tuple[str, str], pd.Series] = {}
+    bitmap_count = 0
+
+    for record in records:
+        if record.author_label_column not in obs.columns:
+            logger.warning(
+                "Skipping bitmap for %s: obs column '%s' not present.",
+                record.node_iri,
+                record.author_label_column,
+            )
+            continue
+
+        cluster_joinids = resolve_cluster_observation_joinids(
+            obs,
+            record.author_label_column,
+            record.author_label_value,
+        )
+        if cluster_joinids.empty:
+            logger.warning(
+                "Skipping bitmap for %s: no matching observation_joinid values.",
+                record.node_iri,
+            )
+            continue
+
+        cache_key = (record.census_dataset_id, record.census_version)
+        if cache_key not in joinid_map_cache:
+            joinid_map_cache[cache_key] = resolve_soma_joinids(
+                record.census_dataset_id, record.census_version
+            )
+
+        joinid_map = joinid_map_cache[cache_key]
+        matched_joinids = cluster_joinids[cluster_joinids.isin(joinid_map.index)]
+        if matched_joinids.empty:
+            logger.warning(
+                "Skipping bitmap for %s: no Census soma_joinid matches found.",
+                record.node_iri,
+            )
+            continue
+
+        soma_joinids = joinid_map.loc[matched_joinids].astype("int64").tolist()
+        write_roaring_bitmap(
+            record.node_iri,
+            record.census_version,
+            soma_joinids,
+            output_dir,
+        )
+        bitmap_count += 1
+        logger.info(
+            "Wrote bitmap for %s (%s cells).",
+            record.cluster_label,
+            len(soma_joinids),
+        )
+
+    logger.info("Bitmap build completed: %s bitmap(s) written.", bitmap_count)
+    return bitmap_count
+
+
+def iter_cluster_bitmap_records(graph) -> Iterable[ClusterBitmapRecord]:
+    for cluster_node in graph.subjects(RDF.type, CELL_CLUSTER_CLASS):
+        author_label_column = _get_first_literal(graph, cluster_node, "author_label_column")
+        if not author_label_column:
+            continue
+
+        dataset_node = _get_first_related_node(
+            graph, cluster_node, "has_source", "source"
+        )
+        if dataset_node is None:
+            continue
+
+        census_dataset_id = _get_first_literal(graph, dataset_node, "census_dataset_id")
+        if not census_dataset_id:
+            continue
+
+        census_version = (
+            _get_first_literal(graph, dataset_node, "census_version_cached") or "stable"
+        )
+        cluster_label = _get_cluster_label(graph, cluster_node)
+        author_label_value = _get_cluster_author_value(
+            graph, cluster_node, author_label_column, cluster_label
+        )
+        if not cluster_label or not author_label_value:
+            continue
+
+        yield ClusterBitmapRecord(
+            node_iri=str(cluster_node),
+            cluster_label=cluster_label,
+            author_label_column=author_label_column,
+            author_label_value=author_label_value,
+            census_dataset_id=census_dataset_id,
+            census_version=census_version,
+        )
+
+
+def resolve_cluster_observation_joinids(
+    obs: pd.DataFrame, author_label_column: str, author_label_value: str
+) -> pd.Series:
+    author_labels = obs[author_label_column].astype(str)
+    observation_joinids = obs["observation_joinid"].astype(str)
+    mask = author_labels == str(author_label_value)
+    return observation_joinids[mask]
+
+
+def resolve_soma_joinids(census_dataset_id: str, census_version: str) -> pd.Series:
+    with cellxgene_census.open_soma(census_version=census_version) as census:
+        for organism in ("homo_sapiens", "mus_musculus"):
+            obs_df = cellxgene_census.get_obs(
+                census,
+                organism,
+                value_filter=f"dataset_id == '{census_dataset_id}'",
+                column_names=["soma_joinid", "observation_joinid"],
+            )
+            if len(obs_df):
+                return obs_df.set_index(
+                    obs_df["observation_joinid"].astype(str)
+                )["soma_joinid"]
+
+    logger.warning(
+        "Dataset %s was not found in Census version %s.",
+        census_dataset_id,
+        census_version,
+    )
+    return pd.Series(dtype="int64")
+
+
+def write_roaring_bitmap(
+    node_iri: str, census_version: str, soma_joinids: Iterable[int], output_dir: str
+) -> str:
+    bitmap = BitMap(soma_joinids)
+    bitmap_path = os.path.join(
+        output_dir,
+        f"{iri_storage_id(node_iri)}__{census_version}.bitmap",
+    )
+    with open(bitmap_path, "wb") as bitmap_file:
+        bitmap_file.write(bitmap.serialize())
+    return bitmap_path
+
+
+def iri_storage_id(node_iri: str) -> str:
+    match = UUID_PATTERN.search(node_iri)
+    if match:
+        return match.group(0).lower()
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, node_iri))
+
+
+def _get_anndata_obs(aea) -> pd.DataFrame:
+    anndata = aea.enricher_manager.anndata
+    return anndata.obs.copy()
+
+
+def _get_rdf_graph(gg):
+    for attr_name in ("rdf_graph", "graph"):
+        graph = getattr(gg, attr_name, None)
+        if graph is not None:
+            return graph
+    raise AttributeError("GraphGenerator does not expose an RDF graph via 'rdf_graph' or 'graph'.")
+
+
+def _get_cluster_label(graph, cluster_node) -> Optional[str]:
+    label = _get_first_literal(graph, cluster_node, "label")
+    if label:
+        return label
+    for obj in graph.objects(cluster_node, RDFS.label):
+        return str(obj)
+    label_rdfs = _get_first_literal(graph, cluster_node, "label_rdfs")
+    if label_rdfs:
+        return label_rdfs
+    return None
+
+
+def _get_cluster_author_value(
+    graph, cluster_node, author_label_column: str, fallback_label: Optional[str]
+) -> Optional[str]:
+    author_value = _get_first_literal(graph, cluster_node, author_label_column)
+    return author_value or fallback_label
+
+
+def _get_first_related_node(graph, subject, *predicate_names: str):
+    for predicate, obj in graph.predicate_objects(subject):
+        if any(
+            _predicate_matches(predicate, predicate_name)
+            for predicate_name in predicate_names
+        ) and isinstance(obj, URIRef):
+            return obj
+    return None
+
+
+def _get_first_literal(graph, subject, predicate_name: str) -> Optional[str]:
+    for predicate, obj in graph.predicate_objects(subject):
+        if _predicate_matches(predicate, predicate_name):
+            return str(obj)
+    return None
+
+
+def _predicate_matches(predicate: URIRef, predicate_name: str) -> bool:
+    predicate_text = unquote(str(predicate))
+    predicate_key = _predicate_key(predicate_text)
+    target_key = _predicate_key(predicate_name)
+    return predicate_key == target_key or predicate_text.endswith(predicate_name)
+
+
+def _predicate_key(value: str) -> str:
+    return value.rsplit("#", 1)[-1].rsplit("/", 1)[-1]

--- a/anndata2rdf/src/bitmaps/README.md
+++ b/anndata2rdf/src/bitmaps/README.md
@@ -1,0 +1,4 @@
+### `bitmaps`
+Contains the bitmap images that are generated from the datasets processed by `anndata2rdf`.
+These files provide visual representations of dataset-derived clusters and are created during
+runtime rather than stored as curated source data.

--- a/anndata2rdf/src/csv_parser.py
+++ b/anndata2rdf/src/csv_parser.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import time
-from typing import Optional
+from typing import Dict, Optional
 
 import pandas as pd
 import requests
@@ -34,13 +34,15 @@ def generate_yaml_data(data):
             for col in group_df["author category cell type field name"].tolist()
         ]
         try:
-            # Fetch the latest dataset link
-            latest_cxg_dataset = fetch_latest_cxg_dataset_link(link)
+            # Fetch the latest dataset metadata
+            latest_cxg_dataset = fetch_latest_cxg_dataset_metadata(link)
             if latest_cxg_dataset:
                 _yaml_data.append(
                     {
                         "CxG_link": link,
-                        "download_url": latest_cxg_dataset,
+                        "download_url": latest_cxg_dataset["download_url"],
+                        "dataset_id": latest_cxg_dataset["dataset_id"],
+                        "dataset_version_id": latest_cxg_dataset["dataset_version_id"],
                         "author_cell_type_list": author_cell_type_list,
                     }
                 )
@@ -57,27 +59,32 @@ def generate_yaml_data(data):
     return _yaml_data
 
 
-def fetch_latest_cxg_dataset_link(link: str) -> Optional[str]:
+def fetch_latest_cxg_dataset_metadata(link: str) -> Optional[Dict[str, str]]:
     """
-    Retrieve the latest CXG dataset download link for the given matrix_id.
+    Retrieve the latest CXG dataset metadata for the given dataset identifier.
 
-    This method extracts the `matrix_id` from the provided URL and sends a GET request
+    This method extracts the dataset identifier from the provided URL and sends a GET request
     to the CXG API to fetch dataset versions. It then parses the response to find the
-    URL of the latest dataset file with the file type "H5AD".
+    latest version entry and returns the stable dataset_id, dataset_version_id,
+    and URL of the latest H5AD asset.
 
     Args:
-        link (str): The URL containing the matrix_id to be extracted. The matrix_id is
+        link (str): The URL containing the dataset identifier to be extracted. That ID is
                     used to query the CXG API for dataset versions.
 
     Returns:
-        Optional[str]: The URL of the latest H5AD dataset file if successful, or None if
-                       the request fails or the desired dataset is not found.
+        Optional[Dict[str, str]]: Metadata for the latest dataset version if successful,
+                                  or None if the request fails or the desired dataset is
+                                  not found.
     """
     retries = 0
     while retries < MAX_RETRIES:
         try:
-            matrix_id = link.split("/")[-2].split(".")[0]
-            request_url = f"https://api.cellxgene.cziscience.com/curation/v1/datasets/{matrix_id}/versions"
+            dataset_lookup_id = link.split("/")[-2].split(".")[0]
+            request_url = (
+                "https://api.cellxgene.cziscience.com/curation/v1/datasets/"
+                f"{dataset_lookup_id}/versions"
+            )
 
             response = requests.get(request_url)
             response.raise_for_status()
@@ -87,12 +94,22 @@ def fetch_latest_cxg_dataset_link(link: str) -> Optional[str]:
                 logger.error("Unexpected API response format or empty dataset list.")
                 return None
 
-            # Find the latest H5AD dataset link
-            for asset in data[0].get("assets", []):
-                if asset.get("filetype") == "H5AD":
-                    return asset.get("url")
+            latest_version = data[0]
+            dataset_id = latest_version.get("dataset_id")
+            dataset_version_id = latest_version.get("dataset_version_id")
 
-            logger.warning(f"No H5AD file found in assets for matrix_id {matrix_id}.")
+            # Find the latest H5AD dataset link
+            for asset in latest_version.get("assets", []):
+                if asset.get("filetype") == "H5AD":
+                    return {
+                        "download_url": asset.get("url"),
+                        "dataset_id": dataset_id,
+                        "dataset_version_id": dataset_version_id,
+                    }
+
+            logger.warning(
+                f"No H5AD file found in assets for dataset identifier {dataset_lookup_id}."
+            )
             return None
 
         except (requests.exceptions.RequestException, ValueError, KeyError) as e:

--- a/anndata2rdf/src/generate_rdf.py
+++ b/anndata2rdf/src/generate_rdf.py
@@ -1,8 +1,9 @@
 import logging
 import os
-from typing import List
+from typing import List, Optional
 import yaml
 
+from bitmap_builder import build_cluster_bitmaps
 from pandasaurus_cxg.enrichment_analysis import AnndataEnrichmentAnalyzer
 from pandasaurus_cxg.graph_generator.graph_generator import GraphGenerator
 
@@ -13,12 +14,16 @@ logger.setLevel(logging.INFO)
 
 
 def generate_rdf_graph(
-    anndata_file_path: str, author_cell_type_list: List[str], output_rdf_path: str
+    anndata_file_path: str,
+    author_cell_type_list: List[str],
+    output_rdf_path: str,
+    dataset_metadata: Optional[dict] = None,
+    bitmap_output_dir: Optional[str] = None,
 ):
     logger.info(f"Generating RDF graph using {anndata_file_path}...")
     aea = AnndataEnrichmentAnalyzer(anndata_file_path, author_cell_type_list)
     aea.analyzer_manager.co_annotation_report()
-    gg = GraphGenerator(aea)
+    gg = GraphGenerator(aea, dataset_metadata=dataset_metadata)
     gg.generate_rdf_graph(merge=True)
     gg.set_label_adding_priority(author_cell_type_list)
     gg.add_label_to_terms()
@@ -31,11 +36,18 @@ def generate_rdf_graph(
         "assay",
         "self_reported_ethnicity",
     ]
-    for field_name in metadata_field_list:
-        if field_name in aea.enricher_manager.anndata.obs.columns:
-            continue
-        metadata_field_list.remove(field_name)
+    metadata_field_list = [
+        field_name
+        for field_name in metadata_field_list
+        if field_name in aea.enricher_manager.anndata.obs.columns
+    ]
     gg.add_metadata_nodes(metadata_fields=metadata_field_list)
+    if bitmap_output_dir is not None:
+        logger.info(f"Building cluster bitmaps in {bitmap_output_dir}...")
+        try:
+            build_cluster_bitmaps(aea, gg, bitmap_output_dir)
+        except Exception:
+            logger.exception("Bitmap build failed; continuing with RDF graph save.")
     gg.save_rdf_graph(file_name=output_rdf_path)
     logger.info(f"RDF graph has been generated for {anndata_file_path}...")
 
@@ -64,4 +76,9 @@ if __name__ == "__main__":
                     else config["anndata_file_path"].split("/")[-1].split(".")[0]
                 ),
             ),
+            {
+                "dataset_id": config.get("dataset_id"),
+                "dataset_version_id": config.get("dataset_version_id"),
+            },
+            os.path.join(dirname, "bitmaps"),
         )

--- a/anndata2rdf/src/process.py
+++ b/anndata2rdf/src/process.py
@@ -24,6 +24,7 @@ CONFIG_DIRECTORY = "config"
 CURATED_DATA_DIRECTORY = "curated_data"
 DATASET_DIRECTORY = "dataset"
 GRAPH_DIRECTORY = "graph"
+BITMAP_DIRECTORY = "bitmaps"
 
 CXG_AUTHOR_CELL_TYPE_CONFIG = "cxg_author_cell_type.yaml"
 GENERATE_RDF_CONFIG = "generate_rdf_config.yaml"
@@ -39,11 +40,18 @@ for dataset in datasets.items():
     matrix_id = dataset[0]
     dataset_url = dataset[1].get("download_url")
     author_cell_types = dataset[1].get("author_cell_type_list")
+    dataset_metadata = {
+        "dataset_id": dataset[1].get("dataset_id"),
+        "dataset_version_id": dataset[1].get("dataset_version_id"),
+    }
     download_id = get_dataset_id_from_link(dataset_url)
 
     rdf_output_path = os.path.join(
         os.path.join(os.path.dirname(os.path.abspath(__file__)), GRAPH_DIRECTORY),
         f"{matrix_id}__{download_id}",
+    )
+    bitmap_output_path = os.path.join(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), BITMAP_DIRECTORY),
     )
     h5ad_output_path = os.path.join(
         os.path.join(os.path.dirname(os.path.abspath(__file__)), DATASET_DIRECTORY),
@@ -63,5 +71,7 @@ for dataset in datasets.items():
             dataset_path,
             author_cell_types,
             rdf_output_path,
+            dataset_metadata,
+            bitmap_output_path,
         )
         delete_file(dataset_path)

--- a/anndata2rdf/src/pull_anndata.py
+++ b/anndata2rdf/src/pull_anndata.py
@@ -185,6 +185,8 @@ def get_dataset_dict(input_source: List[Dict]):
                     matrix_id: {
                         "author_cell_type_list": config["author_cell_type_list"],
                         "download_url": config["download_url"],
+                        "dataset_id": config.get("dataset_id"),
+                        "dataset_version_id": config.get("dataset_version_id"),
                     }
                 }
             )


### PR DESCRIPTION
This PR implements #102 by extending the `anndata2rdf` pipeline to generate cluster bitmap artifacts alongside RDF graph output.

## What changed

- Added bitmap generation to the RDF build flow.
  - `process.py` now provisions a runtime `bitmaps/` output directory and passes bitmap output parameters through the pipeline.
  - `generate_rdf.py` now invokes bitmap generation after RDF graph construction and metadata annotation, while allowing RDF export to continue if bitmap generation fails.

- Added `bitmap_builder.py`.
  - Builds cluster-level roaring bitmap files from generated graph/AnnData context.
  - Resolves cluster membership from author label columns and `observation_joinid`.
  - Maps dataset observations to Census `soma_joinid` values and writes `.bitmap` files.

- Extended dataset metadata flow needed for bitmap generation.
  - `csv_parser.py` now captures dataset metadata from the Cellxgene versions API.
  - `pull_anndata.py` and `process.py` now propagate `dataset_id` and `dataset_version_id` through the runtime pipeline.
  - `generate_rdf.py` passes dataset metadata into `GraphGenerator` so downstream bitmap generation can use dataset/Census identifiers consistently.

- Updated runtime/container setup.
  - Added required dependencies in `anndata2rdf/requirements.txt`.
  - Updated Docker and compose config to include the bitmap builder and mount/persist the bitmap output directory.

## Runtime/output changes

`anndata2rdf` now generates:
- RDF/OWL output in `src/graph/`
- Bitmap artifacts in `src/bitmaps/`

Additional repo hygiene updates:
- Added ignore rules so generated runtime outputs are not committed.
- Added a tracked `src/bitmaps/README.md` to document the directory purpose.

## Why

[Ticket 2 requires](https://github.com/dosumis/CXG_ACT_TRANSFER_POC/blob/main/ROADMAP.md#ticket-2--bitmap-build-integrated-into-graph-build-pipeline) bitmap artifacts to be produced from the same dataset-driven clustering context used for RDF generation, without changing curated source data. This PR wires that into the existing `anndata2rdf` execution path and keeps generated outputs runtime-only.
