### PR TITLE
Update anndata2rdf compose image and add bitmap volume to pipeline

### DIFF
--- a/anndata2rdf/docker-compose.yml
+++ b/anndata2rdf/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   anndata2rdf:
-    image: ghcr.io/cellular-semantics/cl_kg:main
+    image: ghcr.io/cellular-semantics/cl_kg/anndata2rdf:latest
     container_name: anndata_to_rdf
     volumes:
       - ./src/config:/app/src/config

--- a/cl_kb_pipeline/docker-compose.yml
+++ b/cl_kb_pipeline/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   anndata2rdf:
@@ -9,6 +9,7 @@ services:
       - ../anndata2rdf/src/curated_data:/app/src/curated_data
       - ../anndata2rdf/src/dataset:/app/src/dataset
       - ./config/collectdata/local_ontologies:/app/src/graph/
+      - clkg_bitmap_data:/app/src/bitmaps
     command: /bin/sh -c "python src/process.py"
 
   triplestore:
@@ -42,7 +43,7 @@ services:
       - obask_data:/input
       - obask_neo4j_data:/data # for Neo4j DB itself
     healthcheck:
-      test: [ "CMD", "wget", "-O", "-", "http://obask-kb:7474" ]
+      test: ["CMD", "wget", "-O", "-", "http://obask-kb:7474"]
       interval: 18s
       timeout: 12s
       retries: 20
@@ -180,3 +181,4 @@ volumes:
   solr_data:
   triplestore_data:
   obask_neo4j_data:
+  clkg_bitmap_data:


### PR DESCRIPTION
This updates the standalone `anndata2rdf` compose image reference and adds the `clkg_bitmap_data` volume mount to the pipeline compose so bitmap outputs are persisted without changing the existing graph wiring.
